### PR TITLE
Reduce default limit to 1000 as a safer limit

### DIFF
--- a/pywoudc/__init__.py
+++ b/pywoudc/__init__.py
@@ -72,7 +72,7 @@ class WoudcClient(Features):
         self.about = 'https://woudc.org/en/data/data-access'
         """The About Data Access page"""
 
-        self.limit = 25000
+        self.limit = 1000
         """The default limit of features to return"""
 
         LOGGER.info(f'Contacting {self.url}')
@@ -155,7 +155,7 @@ class WoudcClient(Features):
     def get_data(self, collection: str,
                  datetime_: Union[Union[date, datetime, None], list[date, datetime, None]] = None,  # noqa
                  bbox: list = [],
-                 limit: int = 25000,
+                 limit: int = 1000,
                  offset: int = 0,
                  filters: dict = {},
                  sortby: list = []) -> dict:

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -71,7 +71,7 @@ class WoudcClientTest(unittest.TestCase):
                          'https://woudc.org/en/data/data-access',
                          'Expected specific about URL')
 
-        self.assertEqual(self.client.limit, 25000,
+        self.assertEqual(self.client.limit, 1000,
                          'Expected specific default limit')
 
     def test_get_metadata(self):


### PR DESCRIPTION
This PR reduces the default limit to 1000 as certain WOUDC API collections are extremely big in size when queried, which can timeout the request or overload the API.